### PR TITLE
FEM-2703 fix VR lib crash due to removing the surface onPause

### DIFF
--- a/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
+++ b/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
@@ -136,7 +136,7 @@ class VRView extends BaseExoplayerView {
 
         surface.setSecure(isSurfaceSecured);
 
-        if (contentFrame.getChildCount() > 0 &&  !(contentFrame.getChildAt(0) instanceof GLSurfaceView)) {
+        if (contentFrame != null && contentFrame.getChildCount() > 0 &&  !(contentFrame.getChildAt(0) instanceof GLSurfaceView)) {
             contentFrame.addView(surface, 0);
         }
     }
@@ -153,8 +153,6 @@ class VRView extends BaseExoplayerView {
         if (oldTextComponent != null) {
             oldTextComponent.removeTextOutput(componentListener);
         }
-
-        //contentFrame.removeView(surface);
     }
 
     @Override

--- a/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
+++ b/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
@@ -31,7 +31,6 @@ import java.util.List;
 class VRView extends BaseExoplayerView {
 
     private static final PKLog log = PKLog.get("VRView");
-    private Context vrViewContext;
     private View shutterView;
     private SubtitleView subtitleView;
     private AspectRatioFrameLayout contentFrame;
@@ -45,7 +44,6 @@ class VRView extends BaseExoplayerView {
 
     VRView(Context context) {
         this(context, null);
-        this.vrViewContext = context;
     }
 
     VRView(Context context, AttributeSet attrs) {

--- a/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
+++ b/playkitvr/src/main/java/com/kaltura/playkitvr/VRView.java
@@ -31,6 +31,7 @@ import java.util.List;
 class VRView extends BaseExoplayerView {
 
     private static final PKLog log = PKLog.get("VRView");
+    private Context vrViewContext;
     private View shutterView;
     private SubtitleView subtitleView;
     private AspectRatioFrameLayout contentFrame;
@@ -44,6 +45,7 @@ class VRView extends BaseExoplayerView {
 
     VRView(Context context) {
         this(context, null);
+        this.vrViewContext = context;
     }
 
     VRView(Context context, AttributeSet attrs) {
@@ -134,7 +136,9 @@ class VRView extends BaseExoplayerView {
 
         surface.setSecure(isSurfaceSecured);
 
-        contentFrame.addView(surface, 0);
+        if (contentFrame.getChildCount() > 0 &&  !(contentFrame.getChildAt(0) instanceof GLSurfaceView)) {
+            contentFrame.addView(surface, 0);
+        }
     }
 
     /**
@@ -150,7 +154,7 @@ class VRView extends BaseExoplayerView {
             oldTextComponent.removeTextOutput(componentListener);
         }
 
-        contentFrame.removeView(surface);
+        //contentFrame.removeView(surface);
     }
 
     @Override


### PR DESCRIPTION
we should not touch it just keep it in the head of the view group